### PR TITLE
Run PEP8 on content

### DIFF
--- a/run_sample.py
+++ b/run_sample.py
@@ -3,6 +3,7 @@ from util import SampleConfig
 from storage_account_sample import StorageAccountSample
 from sas_definition_sample import SasDefinitionSample
 
+
 def run_all_samples():
 
     config = SampleConfig()

--- a/sas_definition_sample.py
+++ b/sas_definition_sample.py
@@ -19,6 +19,7 @@ class SasDefinitionSample(KeyVaultSampleBase):
     """
     A collection of samples that demonstrate authenticating with the KeyVaultClient and KeyVaultManagementClient
     """
+
     def __init__(self, config=None):
         from azure.keyvault import KeyVaultClient, KeyVaultAuthentication, AccessToken
         from msrestazure.azure_active_directory import ServicePrincipalCredentials
@@ -106,7 +107,8 @@ class SasDefinitionSample(KeyVaultSampleBase):
         service = BlockBlobService(account_name=self.config.storage_account_name,
                                    # don't sign the template with the storage account key use key 00000000
                                    account_key='00000000')
-        permissions = ContainerPermissions(read=True, write=True, delete=True, list=True)
+        permissions = ContainerPermissions(
+            read=True, write=True, delete=True, list=True)
         temp_token = service.generate_container_shared_access_signature(container_name='blobcontainer',
                                                                         permission=permissions,
                                                                         expiry='2020-01-01')

--- a/storage_account_sample.py
+++ b/storage_account_sample.py
@@ -19,6 +19,7 @@ class StorageAccountSample(KeyVaultSampleBase):
     """
     A collection of samples that demonstrate authenticating with the KeyVaultClient and KeyVaultManagementClient
     """
+
     def __init__(self, config=None):
         from azure.keyvault import KeyVaultClient, KeyVaultAuthentication, AccessToken
         from msrestazure.azure_active_directory import ServicePrincipalCredentials
@@ -38,7 +39,8 @@ class StorageAccountSample(KeyVaultSampleBase):
             token = self.get_user_token(resource=resource)
             return AccessToken(scheme=token['tokenType'], token=token['accessToken'], key=None)
 
-        self.keyvault_user_client = KeyVaultClient(KeyVaultAuthentication(authorization_callback=authenticate_user))
+        self.keyvault_user_client = KeyVaultClient(
+            KeyVaultAuthentication(authorization_callback=authenticate_user))
 
         self._user_id = None
         self._user_oid = None
@@ -69,10 +71,12 @@ class StorageAccountSample(KeyVaultSampleBase):
         # authenticated through device login rather than the service principal credentials used
         # in other samples.
         # create the StorageManagementClient with user token credentials
-        user_token_creds = AADTokenCredentials(self.get_user_token('https://management.core.windows.net/'))
+        user_token_creds = AADTokenCredentials(
+            self.get_user_token('https://management.core.windows.net/'))
 
-        print('creating storage account %s'%self.config.storage_account_name)
-        storage_mgmt_client = StorageManagementClient(user_token_creds, self.config.subscription_id)
+        print('creating storage account %s' % self.config.storage_account_name)
+        storage_mgmt_client = StorageManagementClient(
+            user_token_creds, self.config.subscription_id)
 
         # create the storage account
         sa_params = StorageAccountCreateParameters(sku=Sku(SkuName.standard_ragrs),
@@ -88,15 +92,18 @@ class StorageAccountSample(KeyVaultSampleBase):
         print('granting Azure Key Vault the "Storage Account Key Operator Service Role" on the storage account')
         # find the role definition for "Storage Account Key Operator Service Role"
         filter_str = 'roleName eq \'Storage Account Key Operator Service Role\''
-        authorization_mgmt_client = AuthorizationManagementClient(user_token_creds, self.config.subscription_id)
-        role_id = list(authorization_mgmt_client.role_definitions.list(scope='/', filter=filter_str))[0].id
+        authorization_mgmt_client = AuthorizationManagementClient(
+            user_token_creds, self.config.subscription_id)
+        role_id = list(authorization_mgmt_client.role_definitions.list(
+            scope='/', filter=filter_str))[0].id
 
         # create a role assignment granting the key vault service principal this role
         role_params = RoleAssignmentCreateParameters(role_definition_id=role_id,
                                                      # the Azure Key Vault service id
                                                      principal_id='93c27d83-f79b-4cb2-8dd4-4aa716542e74')
         authorization_mgmt_client.role_assignments.create(scope=sa.id,
-                                                          role_assignment_name=str(uuid.uuid4()),
+                                                          role_assignment_name=str(
+                                                              uuid.uuid4()),
                                                           parameters=role_params)
 
         # since the set_storage_account can only be called by a user account with access to the keys of
@@ -108,7 +115,8 @@ class StorageAccountSample(KeyVaultSampleBase):
         self.grant_access_to_sample_vault(vault, self._user_oid)
 
         # add the storage account to the vault using the users KeyVaultClient
-        print('adding storage acount %s to vault %s' % (self.config.storage_account_name, vault.name))
+        print('adding storage acount %s to vault %s' %
+              (self.config.storage_account_name, vault.name))
         attributes = StorageAccountAttributes(enabled=True)
         self.keyvault_user_client.set_storage_account(vault_base_url=self.sample_vault_url,
                                                       storage_account_name=sa.name,
@@ -177,7 +185,8 @@ class StorageAccountSample(KeyVaultSampleBase):
         """
         Deletes a storage account from a vault.
         """
-        print('deleting storage account %s from the vault' % self.config.storage_account_name)
+        print('deleting storage account %s from the vault' %
+              self.config.storage_account_name)
         self.keyvault_sp_client.delete_storage_account(vault_base_url=self.sample_vault_url,
                                                        storage_account_name=self.config.storage_account_name)
 

--- a/util.py
+++ b/util.py
@@ -25,13 +25,15 @@ STORAGE_PERMISSIONS_ALL = [perm.value for perm in StoragePermissions]
 
 _rand = Random()
 
+
 def get_name(base, delimiter='-'):
     """
     randomly builds a unique name for an entity beginning with the specified base 
     :param base: the prefix for the generated name
     :return: a random unique name
     """
-    name = '{}{}{}{}{}'.format(base, delimiter, _rand.choice(adjectives), delimiter, _rand.choice(nouns))
+    name = '{}{}{}{}{}'.format(base, delimiter, _rand.choice(
+        adjectives), delimiter, _rand.choice(nouns))
     if len(name) < 22:
         name += delimiter
         for i in range(min(5, 23 - len(name))):
@@ -43,6 +45,7 @@ def keyvaultsample(f):
     """
     decorator function for marking key vault sample methods
     """
+
     def wrapper(self):
         try:
             print('--------------------------------------------------------------------')
@@ -52,7 +55,8 @@ def keyvaultsample(f):
             f(self)
         except Exception as e:
             print('ERROR: running sample failed with raised exception:')
-            traceback.print_exception(type(e), e, getattr(e, '__traceback__', None))
+            traceback.print_exception(
+                type(e), e, getattr(e, '__traceback__', None))
             raise e
     wrapper.__name__ = f.__name__
     wrapper.__doc__ = f.__doc__
@@ -95,7 +99,8 @@ class SampleConfig(object):
         self.client_secret = os.getenv('AZURE_CLIENT_SECRET', None)
         self.client_oid = os.getenv('AZURE_CLIENT_OID', None)
         self.location = os.getenv('AZURE_LOCATION', None)
-        self.group_name = os.getenv('AZURE_RESOURCE_GROUP', 'azure-key-vault-samples')
+        self.group_name = os.getenv(
+            'AZURE_RESOURCE_GROUP', 'azure-key-vault-samples')
         self.storage_account_name = os.getenv('AZURE_STORAGE_NAME', None)
         self.vault_name = os.getenv('AZURE_VAULT_NAME', None)
         self.mgmt_client_creds = None
@@ -132,15 +137,17 @@ class KeyVaultSampleBase(object):
         """
         Provides common setup for Key Vault samples, such as creating rest clients, creating a sample resource group
         if needed, and ensuring proper access for the service principal.
-         
+
         :return: None 
         """
 
         if not KeyVaultSampleBase._setup_complete:
 
-            self.config.auth_context = adal.AuthenticationContext('https://login.microsoftonline.com/%s' % self.config.tenant_id)
+            self.config.auth_context = adal.AuthenticationContext(
+                'https://login.microsoftonline.com/%s' % self.config.tenant_id)
 
-            resource_mgmt_client = ResourceManagementClient(self.mgmt_client_creds, self.config.subscription_id)
+            resource_mgmt_client = ResourceManagementClient(
+                self.mgmt_client_creds, self.config.subscription_id)
 
             # ensure the service principle has key vault and storage as valid providers
             resource_mgmt_client.providers.register('Microsoft.KeyVault')
@@ -167,8 +174,8 @@ class KeyVaultSampleBase(object):
                                    permissions=permissions)
 
         vault.properties.access_policies.append(policy)
-        return keyvault_mgmt_client.vaults.create_or_update(resource_group_name=self.config.group_name, 
-                                                            vault_name=vault.name, 
+        return keyvault_mgmt_client.vaults.create_or_update(resource_group_name=self.config.group_name,
+                                                            vault_name=vault.name,
                                                             parameters=vault).result()
 
     def get_sample_vault(self):
@@ -180,7 +187,8 @@ class KeyVaultSampleBase(object):
 
         if not self.config.vault:
 
-            keyvault_mgmt_client = KeyVaultManagementClient(self.mgmt_client_creds, self.config.subscription_id)
+            keyvault_mgmt_client = KeyVaultManagementClient(
+                self.mgmt_client_creds, self.config.subscription_id)
 
             if self.config.vault_name:
                 vault = keyvault_mgmt_client.vaults.get(resource_group_name=self.config.group_name,


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.